### PR TITLE
chore: onboard stepsecurity and apply security best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,16 @@ jobs:
   run_ci_tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "20.14.0"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,14 @@ permissions:
 jobs:
   run_ci_tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
## Summary
This pull request improves the security and reliability of the CI workflow by hardening the runner environment and pinning GitHub Action dependencies to specific commit SHAs. These changes help prevent supply chain attacks and ensure consistent builds.

## Detail
Security hardening:

* Added the `step-security/harden-runner` action to the workflow to block unauthorized network egress and apply a global allowed endpoints policy.
* Set the `id-token` permission to `write` for the workflow, which may be required for secure authentication with cloud providers or other services.

Dependency management:

* Updated `actions/checkout` and `actions/setup-node` steps to use pinned commit SHAs instead of version tags, reducing the risk of unexpected changes in dependencies.

## Testing
- [ ] 100% test coverage is maintained

## Documentation

---

**Requested Reviewers:** @mention